### PR TITLE
 #4 - implemented custom onLoadComplete handler for non-chunked uploads

### DIFF
--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -17,7 +17,7 @@ const Demo = () => (
       <XHRUploader url={UPLOAD_URL} />
     </article>
     <article>
-      <p>By default, the component uses POST method for file transfer. The component accepts the 
+      <p>By default, the component uses POST method for file transfer. The component accepts the
       </p><pre>method</pre><p> property to specify different http method.</p>
       <pre style={{fontSize: 10}}>
         {`
@@ -28,6 +28,20 @@ const Demo = () => (
         `}
       </pre>
       <XHRUploader url={UPLOAD_URL} method="PUT" />
+    </article>
+    <article>
+      <p>To set up handler handling responses after upload (successful or not) use
+      </p><pre>onLoadComplete</pre><p> property.</p>
+      <p className="alert"><strong>Note:</strong> This property is supported with non-chunked uploads only.</p>
+      <pre style={{fontSize: 10}}>
+        {`
+          <XHRUploader
+            url='${UPLOAD_URL}'
+            onLoadComplete={(response) => console.log(response)}
+          />
+        `}
+      </pre>
+      <XHRUploader url={UPLOAD_URL} onLoadComplete={response => console.log(response)} />
     </article>
     <article>
       <p>You can enable automatic upload after drag and drop or file selection with </p>

--- a/demo/main.css
+++ b/demo/main.css
@@ -263,3 +263,7 @@ a {
 .menu__all-charts {
   color: #fba600 !important;
 }
+
+.alert {
+  color: firebrick;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,9 @@ class XHRUploader extends Component {
       formData.append(this.props.fieldName, file, file.name);
 
       xhr.onload = () => {
+        if (this.props.onLoadComplete) {
+          this.props.onLoadComplete(xhr.response);
+        }
         progressCallback(100);
       };
 
@@ -315,7 +318,8 @@ XHRUploader.propTypes = {
   cancelIconClass: PropTypes.string,
   completeIconClass: PropTypes.string,
   uploadIconClass: PropTypes.string,
-  progressClass: PropTypes.string
+  progressClass: PropTypes.string,
+  onLoadComplete: PropTypes.func
 };
 
 XHRUploader.defaultProps = {


### PR DESCRIPTION
In current non-chunked implementation it is straightforward to implement onLoadComplete handler. However it is not so simple for current chunked form and I also checked w3c spec for chunked requests and I think this implementation does not respect it.  From this reason I implemented just simple onLoadComplete handler for non-chunked uploads. 

I'm opened to discussion about this PR - If you think that it should be implemented in both versions, feel free to decline this PR.

