### PR TITLE
update react css transition lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.14.1",
-    "webpack-merge": "^0.14.1"
+    "webpack-merge": "^0.14.1",
+    "react-transition-group": "^2.2.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import ReactCSSTransitionGroup from 'react-transition-group';
 import defaultStyles from './styles';
 
 class XHRUploader extends Component {


### PR DESCRIPTION
drop react-addons-css-transition-group in favour of react-transition-group as it was deprecated and dropped in last React 16.

Solves https://github.com/rma-consulting/react-xhr-uploader/issues/21