### PR TITLE
fix bad CSSTransitionGroup import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactCSSTransitionGroup from 'react-transition-group';
+import { CSSTransitionGroup } from 'react-transition-group';
 import defaultStyles from './styles';
 
 class XHRUploader extends Component {
@@ -232,7 +232,12 @@ class XHRUploader extends Component {
       const cancelledItems = items.filter(item => item.cancelled === true);
       const filesetStyle = items.length === cancelledItems.length ? { display: 'none' } : styles.fileset;
       return (
-        <ReactCSSTransitionGroup component="div" transitionName={transitionName} transitionEnterTimeout={0} transitionLeaveTimeout={0}>
+        <CSSTransitionGroup
+          component="div"
+          transitionName={transitionName}
+          transitionEnterTimeout={0}
+          transitionLeaveTimeout={0}
+        >
           <div style={filesetStyle}>
             {items.filter(item => !item.cancelled && !!item.file).map(item => {
               const file = item.file;
@@ -268,11 +273,16 @@ class XHRUploader extends Component {
               );
             })}
           </div>
-        </ReactCSSTransitionGroup>
+        </CSSTransitionGroup>
       );
     }
     return (
-      <ReactCSSTransitionGroup component="div" transitionName={transitionName} transitionEnterTimeout={0} transitionLeaveTimeout={0} />
+      <CSSTransitionGroup
+        component="div"
+        transitionName={transitionName}
+        transitionEnterTimeout={0}
+        transitionLeaveTimeout={0}
+      />
     );
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { CSSTransitionGroup } from 'react-transition-group';
+import { TransitionGroup } from 'react-transition-group';
 import defaultStyles from './styles';
 
 class XHRUploader extends Component {
@@ -232,7 +232,7 @@ class XHRUploader extends Component {
       const cancelledItems = items.filter(item => item.cancelled === true);
       const filesetStyle = items.length === cancelledItems.length ? { display: 'none' } : styles.fileset;
       return (
-        <CSSTransitionGroup
+        <TransitionGroup
           component="div"
           transitionName={transitionName}
           transitionEnterTimeout={0}
@@ -273,11 +273,11 @@ class XHRUploader extends Component {
               );
             })}
           </div>
-        </CSSTransitionGroup>
+        </TransitionGroup>
       );
     }
     return (
-      <CSSTransitionGroup
+      <TransitionGroup
         component="div"
         transitionName={transitionName}
         transitionEnterTimeout={0}


### PR DESCRIPTION
The current version of the import gives us back an object, which prevents the component to render and throws an error.
This PR fixes this :) 