### PR TITLE
Added the option of passing more form data

### DIFF
--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -76,6 +76,29 @@ const Demo = () => (
       <XHRUploader url={UPLOAD_URL} auto chunks chunkSize={512 * 1024} />
     </article>
     <article>
+      <p>Pass more form data with</p>
+      <pre>formData</pre>
+      <pre style={{ fontSize: 10 }}>
+        {`
+        <XHRUploader
+          url='${UPLOAD_URL}'
+          formData={
+            [{
+              name: 'serverPath',
+              value: 'myPath'
+            }, {
+              name: 'id',
+              value: someId
+            }, {
+              ...
+            }]
+          }
+        />
+      `}
+      </pre>
+      <XHRUploader url={UPLOAD_URL} formData={[{name: 'serverPath', value: 'myPath'}]}/>
+    </article>
+    <article>
       <h2>Customising look and feel</h2>
       <p>The component accepts a </p>
       <pre>style</pre>

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,13 @@ class XHRUploader extends Component {
     if (blob) {
       const formData = new FormData();
       const xhr = new XMLHttpRequest();
+      const data = this.props.formData;
+
+      if(data.length > 0){
+        data.map( d => {
+          formData.append(d.name, d.value);
+        })
+      }
 
       formData.append(this.props.fieldName, blob, `${fileName}-chunk${chunkIndex}`);
 
@@ -163,6 +170,13 @@ class XHRUploader extends Component {
     if (file) {
       const formData = new FormData();
       const xhr = new XMLHttpRequest();
+      const data = this.props.formData;
+
+      if(data.length > 0){
+        data.map( d => {
+          formData.append(d.name, d.value);
+        })
+      }
 
       formData.append(this.props.fieldName, file, file.name);
 
@@ -359,7 +373,11 @@ XHRUploader.propTypes = {
   cancelIconClass: PropTypes.string,
   completeIconClass: PropTypes.string,
   uploadIconClass: PropTypes.string,
-  progressClass: PropTypes.string
+  progressClass: PropTypes.string,
+  formData: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  }))
 };
 
 XHRUploader.defaultProps = {
@@ -378,7 +396,8 @@ XHRUploader.defaultProps = {
   filesetTransitionName: 'fileset',
   cancelIconClass: 'fa fa-close',
   completeIconClass: 'fa fa-check',
-  uploadIconClass: 'fa fa-upload'
+  uploadIconClass: 'fa fa-upload',
+  formData: []
 };
 
 export default XHRUploader;


### PR DESCRIPTION
I added the option of passing additional form data.
This could be useful, for example, when you want to pass a parameter (or more than one) specifying path destination in the server.

```
<XHRUploader 
    url='yourURL' 
    formData={
        [{
            name: 'paramName1',
            value: 'paramValue1'
       }, {
           name: 'paramName2',
            value: 'paramValue2'
      }]
}
/>
```

Hope you like it.